### PR TITLE
feat: global하게 사용되는 기능들 추가

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/common/config/JpaAuditingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package datastreams_knu.bigpicture.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/datastreams_knu/bigpicture/common/domain/ApiResponse.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/domain/ApiResponse.java
@@ -1,0 +1,38 @@
+package datastreams_knu.bigpicture.common.domain;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiResponse<T> {
+
+    private int code;
+    private HttpStatus status;
+    private String message;
+    private T data;
+
+    public ApiResponse(HttpStatus status, String message, T data) {
+        this.code = status.value();
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
+        return new ApiResponse<>(httpStatus, message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, T data) {
+        return of(httpStatus, httpStatus.name(), data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message) {
+        return of(httpStatus, message, null);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return of(HttpStatus.OK, data);
+    }
+
+}
+

--- a/src/main/java/datastreams_knu/bigpicture/common/domain/BaseEntity.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/domain/BaseEntity.java
@@ -1,0 +1,26 @@
+package datastreams_knu.bigpicture.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Data
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Column(name = "created_at", updatable = false)
+    @CreatedDate
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private Instant updatedAt;
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #2 


## 📝 작업 내용
> EnableJpaAuditing으로 created_at, updated_at 기능 구현
> 공통화된 응답을 위한 ApiResponse 추가

### 스크린샷 (선택)

-

## 💬 리뷰 요구사항(선택)

> ApiResponse에 더 필요하신 응답 형태가 있으시다면 추가해서 사용하시면 됩니다!


## ⏰ 현재 버그

-

## ✏ Git Close
> close #2