### PR TITLE
feat: 외부 api 호출을 위한 webClient 유틸리티 클래스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,26 @@ repositories {
 }
 
 dependencies {
+    // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Database
+    runtimeOnly 'com.h2database:h2'
+
+    // AI / LangChain
+    implementation 'dev.langchain4j:langchain4j-open-ai:1.0.0-beta1'
+    implementation 'dev.langchain4j:langchain4j:1.0.0-beta1'
+
+    // Web Scraping
+    implementation 'org.jsoup:jsoup:1.15.3'
+
+    // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/datastreams_knu/bigpicture/common/config/WebClientConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/config/WebClientConfig.java
@@ -1,0 +1,22 @@
+package datastreams_knu.bigpicture.common.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        HttpClient option = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000);
+
+        return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(option))
+            .build();
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/common/util/WebClientUtil.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/util/WebClientUtil.java
@@ -1,0 +1,20 @@
+package datastreams_knu.bigpicture.common.util;
+
+import datastreams_knu.bigpicture.common.config.WebClientConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WebClientUtil {
+
+    private final WebClientConfig webClientConfig;
+
+    public <T> T get(String url, Class<T> clazz) {
+        return webClientConfig.webClient().get()
+            .uri(url)
+            .retrieve()
+            .bodyToMono(clazz)
+            .block();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #-


## 📝 작업 내용
> 외부 api 호출을 편리하게 하기 위한 webClient get 유틸리티 클래스를 추가하였습니다.
> build.gradle도 용도에 따라 정리하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-