### PR TITLE
feat: transaction added on NewsCrawlingAgent

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/news/config/NewsCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/config/NewsCrawlingConfig.java
@@ -16,7 +16,7 @@ public class NewsCrawlingConfig {
     private final NewsCrawlingAgent newsCrawlingAgent;
 
     @Bean
-    public NewsCrawlingAssistant assistant() {
+    public NewsCrawlingAssistant newsCrawlingAssistant() {
         return AiServices.builder(NewsCrawlingAssistant.class)
             .chatLanguageModel(aiModelConfig.openAiChatModel())
             .tools(newsCrawlingAgent)

--- a/src/main/java/datastreams_knu/bigpicture/news/service/NewsCrawlingService.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/service/NewsCrawlingService.java
@@ -1,28 +1,25 @@
 package datastreams_knu.bigpicture.news.service;
 
 import datastreams_knu.bigpicture.news.agent.NewsCrawlingAssistant;
+import datastreams_knu.bigpicture.news.agent.dto.NewsCrawlingResultDto;
 import datastreams_knu.bigpicture.news.config.NewsCrawlingConfig;
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 @Service
 public class NewsCrawlingService {
 
     private final NewsCrawlingConfig newsCrawlingConfig;
+    private final NewsCrawlingAssistant newsCrawlingAssistant;
 
-    private NewsCrawlingAssistant assistant;
-
-    @PostConstruct
-    public void setup() {
-        this.assistant = newsCrawlingConfig.assistant();
+    public NewsCrawlingService(NewsCrawlingConfig newsCrawlingConfig,
+                               NewsCrawlingAssistant newsCrawlingAssistant) {
+        this.newsCrawlingConfig = newsCrawlingConfig;
+        this.newsCrawlingAssistant = newsCrawlingConfig.newsCrawlingAssistant();
     }
 
-    @Transactional
-    public void crawling(String type, String keyword) {
-        assistant.execute(type, keyword);
+    public NewsCrawlingResultDto crawling(String type, String keyword) {
+        return newsCrawlingAssistant.execute(type, keyword);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 뉴스 크롤링 에이전트 레이어에 트랜잭션 추가되었습니다.
서비스 레이어에 트랜잭션이 현재 랭체인으로 실행된 task에는 적용되지 않음을 확인했고 AOP 기반의 @Transactional을 사용하면 에이전트가 툴을 찾지못하는 버그가 있어 transaction template으로 직접 트랜잭션을 적용하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-