### PR TITLE
feat: 한국 금리 데이터 크롤링 기능 추가

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/interest/agent/InterestCrawlingAgent.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/agent/InterestCrawlingAgent.java
@@ -1,0 +1,102 @@
+package datastreams_knu.bigpicture.interest.agent;
+
+import datastreams_knu.bigpicture.common.config.AiModelConfig;
+import datastreams_knu.bigpicture.common.util.WebClientUtil;
+import datastreams_knu.bigpicture.interest.agent.dto.InterestCrawlingResultDto;
+import datastreams_knu.bigpicture.interest.agent.dto.KoreaInterestCrawlingDto;
+import datastreams_knu.bigpicture.interest.domain.KoreaInterest;
+import datastreams_knu.bigpicture.interest.repository.InterestRepository;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static datastreams_knu.bigpicture.interest.agent.dto.KoreaInterestCrawlingDto.StatisticRow;
+
+@Component
+public class InterestCrawlingAgent {
+
+    private final WebClientUtil webClientUtil;
+    private final AiModelConfig aiModelConfig;
+    private final InterestRepository interestRepository;
+    private final TransactionTemplate txTemplate;
+
+    public InterestCrawlingAgent(InterestRepository interestRepository, AiModelConfig aiModelConfig, WebClientUtil webClientUtil, PlatformTransactionManager transactionManager) {
+        this.interestRepository = interestRepository;
+        this.aiModelConfig = aiModelConfig;
+        this.webClientUtil = webClientUtil;
+        this.txTemplate = new TransactionTemplate(transactionManager);
+    }
+
+    private ChatLanguageModel model;
+
+    @Value("${ecos.api.url}")
+    private String ecosBaseUrl;
+    @Value("${ecos.api.key}")
+    private String ecosApiKey;
+
+    @PostConstruct
+    private void setup() {
+        this.model = aiModelConfig.openAiChatModel();
+    }
+
+    @Tool("지난 n년 동안의 한국 금리를 크롤링합니다.")
+    public KoreaInterestCrawlingDto crawlingInterestsOfKorea(int n) {
+        String dateRange = getDateRange(n);
+        String url = createUrl(dateRange);
+        return webClientUtil.get(url, KoreaInterestCrawlingDto.class);
+    }
+
+    @Tool("크롤링 된 지난 5년 동안의 한국 금리를 DB에 저장하고 처리 성공 여부를 반환합니다.")
+    public InterestCrawlingResultDto saveKoreaInterest(KoreaInterestCrawlingDto koreaInterestCrawlingDto) {
+        return txTemplate.execute((status) -> {
+            try {
+                List<StatisticRow> interestDataRows = koreaInterestCrawlingDto.getStatisticSearch().getRow();
+                for (StatisticRow row : interestDataRows) {
+                    LocalDate interestDate = parseStringToLocalDate(row.getTime());
+                    Float interestRate = Float.parseFloat(row.getDataValue());
+                    KoreaInterest koreaInterest = KoreaInterest.of(interestDate, interestRate);
+                    interestRepository.save(koreaInterest);
+                }
+                return InterestCrawlingResultDto.of(true, "성공");
+            } catch (Exception e) {
+                return InterestCrawlingResultDto.of(false, "실패");
+            }
+        });
+    }
+
+    private static LocalDate parseStringToLocalDate(String dateString) {
+        YearMonth yearMonth = YearMonth.parse(dateString, DateTimeFormatter.ofPattern("yyyyMM"));
+        return yearMonth.atDay(1);
+    }
+
+    private String createUrl(String dateRange) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(ecosBaseUrl);
+        sb.append(ecosApiKey);
+        sb.append("/json/kr/1/1000/722Y001/M/");
+        sb.append(dateRange);
+        sb.append("/0101000");
+        return sb.toString();
+    }
+
+    private static String getDateRange(int year) {
+        YearMonth yearMonth = YearMonth.from(LocalDate.now());
+        String formattedYearMonthDay = formatYearMonth(yearMonth); // 오늘 기준 년월
+        YearMonth fiveYearsAgoYearMonth = yearMonth.minusYears(year);
+        String formattedYearMonthFiveYearsAgo = formatYearMonth(fiveYearsAgoYearMonth);
+        return formattedYearMonthFiveYearsAgo + "/" + formattedYearMonthDay;
+    }
+
+    private static String formatYearMonth(YearMonth yearMonth) {
+        return yearMonth.toString().replace("-", "");
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/agent/InterestCrawlingAssistant.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/agent/InterestCrawlingAssistant.java
@@ -1,0 +1,30 @@
+package datastreams_knu.bigpicture.interest.agent;
+
+import datastreams_knu.bigpicture.interest.agent.dto.InterestCrawlingResultDto;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+public interface InterestCrawlingAssistant {
+    @SystemMessage("""
+            당신은 뉴스 크롤링 어시스턴트입니다.
+            
+            'type' 값에 따라 서로 다른 방식으로 금리 데이터를 수집하세요:
+            
+            1. **한국 금리 데이터 수집 (type == 'korea')**
+                역할:
+                - 금리 데이터 수집: 한국의 지난 n년 동안의 금리 데이터를 수집합니다.
+                - 결과 저장: 수집된 결과를 DB에 저장합니다.
+               
+            2. **미국 금리 데이터 수집 (type == 'us')**
+               - 금리 데이터 수집: 미국의 지난 n년 동안의 금리 데이터를 수집합니다.
+               - 결과 저장: 수집된 결과를 DB에 저장합니다.
+            
+            **응답 형식**
+            - JSON 형태로 반환하며, 처리 성공 여부를 포함해야 합니다.
+            
+            정확하고 유용한 뉴스만 제공하세요.
+        """)
+    @UserMessage("type: {{type}}, n: {{n}}")
+    InterestCrawlingResultDto execute(@V("type") String type, @V("n") int n);
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/agent/InterestCrawlingAssistant.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/agent/InterestCrawlingAssistant.java
@@ -7,7 +7,7 @@ import dev.langchain4j.service.V;
 
 public interface InterestCrawlingAssistant {
     @SystemMessage("""
-            당신은 뉴스 크롤링 어시스턴트입니다.
+            당신은 금리 데이터 크롤링 어시스턴트입니다.
             
             'type' 값에 따라 서로 다른 방식으로 금리 데이터를 수집하세요:
             

--- a/src/main/java/datastreams_knu/bigpicture/interest/agent/dto/InterestCrawlingResultDto.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/agent/dto/InterestCrawlingResultDto.java
@@ -1,0 +1,24 @@
+package datastreams_knu.bigpicture.interest.agent.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class InterestCrawlingResultDto {
+
+    private Boolean result;
+    private String message;
+
+    @Builder
+    public InterestCrawlingResultDto(Boolean result, String message) {
+        this.result = result;
+        this.message = message;
+    }
+
+    public static InterestCrawlingResultDto of(Boolean result, String message) {
+        return InterestCrawlingResultDto.builder()
+            .result(result)
+            .message(message)
+            .build();
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/agent/dto/KoreaInterestCrawlingDto.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/agent/dto/KoreaInterestCrawlingDto.java
@@ -1,0 +1,29 @@
+package datastreams_knu.bigpicture.interest.agent.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+public class KoreaInterestCrawlingDto {
+    @JsonProperty("StatisticSearch")
+    private StatisticSearch statisticSearch;
+
+    @Getter
+    public static class StatisticSearch {
+        @JsonProperty("row")
+        private List<StatisticRow> row;
+    }
+
+    @ToString
+    @Getter
+    public static class StatisticRow {
+        @JsonProperty("TIME")
+        private String time;
+
+        @JsonProperty("DATA_VALUE")
+        private String dataValue;
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/config/InterestCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/config/InterestCrawlingConfig.java
@@ -1,0 +1,25 @@
+package datastreams_knu.bigpicture.interest.config;
+
+import datastreams_knu.bigpicture.common.config.AiModelConfig;
+import datastreams_knu.bigpicture.interest.agent.InterestCrawlingAgent;
+import datastreams_knu.bigpicture.interest.agent.InterestCrawlingAssistant;
+import dev.langchain4j.service.AiServices;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class InterestCrawlingConfig {
+
+    private final AiModelConfig aiModelConfig;
+    private final InterestCrawlingAgent interestCrawlingAgent;
+
+    @Bean
+    public InterestCrawlingAssistant interestCrawlingAssistant() {
+        return AiServices.builder(InterestCrawlingAssistant.class)
+            .chatLanguageModel(aiModelConfig.openAiChatModel())
+            .tools(interestCrawlingAgent)
+            .build();
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/domain/KoreaInterest.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/domain/KoreaInterest.java
@@ -1,0 +1,36 @@
+package datastreams_knu.bigpicture.interest.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Entity
+public class KoreaInterest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate interestDate;
+
+    private Float interestRate;
+
+    @Builder
+    public KoreaInterest(LocalDate interestDate, Float interestRate) {
+        this.interestDate = interestDate;
+        this.interestRate = interestRate;
+    }
+
+    public static KoreaInterest of(LocalDate interestDate, Float interestRate) {
+        return KoreaInterest.builder()
+            .interestDate(interestDate)
+            .interestRate(interestRate)
+            .build();
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/repository/InterestRepository.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/repository/InterestRepository.java
@@ -1,0 +1,7 @@
+package datastreams_knu.bigpicture.interest.repository;
+
+import datastreams_knu.bigpicture.interest.domain.KoreaInterest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterestRepository extends JpaRepository<KoreaInterest, Long> {
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/service/InterestCrawlingService.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/service/InterestCrawlingService.java
@@ -1,0 +1,25 @@
+package datastreams_knu.bigpicture.interest.service;
+
+import datastreams_knu.bigpicture.interest.agent.InterestCrawlingAssistant;
+import datastreams_knu.bigpicture.interest.agent.dto.InterestCrawlingResultDto;
+import datastreams_knu.bigpicture.interest.config.InterestCrawlingConfig;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class InterestCrawlingService {
+
+    private final InterestCrawlingConfig interestCrawlingConfig;
+    private final InterestCrawlingAssistant interestCrawlingAssistant;
+
+    public InterestCrawlingService(InterestCrawlingConfig interestCrawlingConfig,
+                                   InterestCrawlingAssistant interestCrawlingAssistant) {
+        this.interestCrawlingConfig = interestCrawlingConfig;
+        this.interestCrawlingAssistant = interestCrawlingAssistant;
+    }
+
+    public InterestCrawlingResultDto crawling(String type, int n) {
+        return interestCrawlingAssistant.execute(type, n);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 한국 금리 데이터 크롤링 기능을 추가하였습니다.
ECOS를 사용하고 파라미터 n에 따라 지난 n년 동안의 한국 금리 데이터를 한달 간격으로 크롤링합니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/cc4e956c-3495-4b2a-ae97-a548835b20c6)

## 💬 리뷰 요구사항(선택)
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-