### PR TITLE
deploy: Dockerfile 베이스 이미지 교체

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 1. JDK 17이 포함된 가벼운 베이스 이미지 사용
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
 
 # 2. 작업 디렉토리 설정
 WORKDIR /app


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> Dockerfile 베이스 이미지 교체(amd -> arm/amd)

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> -


## ⏰ 현재 버그
라즈베리파이에서 amd를 지원안해서 arm/amd 모두 지원하는 이미지로 전환


## ✏ Git Close
> close #-