### PR TITLE
feat: initial data generator endpoint 추가

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/news/agent/NewsCrawlingAgent.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/agent/NewsCrawlingAgent.java
@@ -47,7 +47,6 @@ public class NewsCrawlingAgent {
     private final AiModelConfig aiModelConfig;
     private final ObjectMapper objectMapper;
     private final NewsRepository newsRepository;
-    private final ReferenceRepository referenceRepository;
 
     private ChatLanguageModel model;
 

--- a/src/main/java/datastreams_knu/bigpicture/news/service/NewsCrawlingService.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/service/NewsCrawlingService.java
@@ -1,28 +1,229 @@
 package datastreams_knu.bigpicture.news.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import datastreams_knu.bigpicture.common.config.AiModelConfig;
 import datastreams_knu.bigpicture.common.dto.CrawlingResultDto;
+import datastreams_knu.bigpicture.common.dto.DateRangeDto;
+import datastreams_knu.bigpicture.common.util.WebClientUtil;
 import datastreams_knu.bigpicture.news.agent.NewsCrawlingAssistant;
+import datastreams_knu.bigpicture.news.agent.dto.CrawledNewsDto;
+import datastreams_knu.bigpicture.news.agent.dto.StringSummaryDto;
+import datastreams_knu.bigpicture.news.agent.dto.SummarizedMultipleNewsDto;
+import datastreams_knu.bigpicture.news.agent.dto.SummarizedNewsDto;
 import datastreams_knu.bigpicture.news.config.NewsCrawlingConfig;
+import datastreams_knu.bigpicture.news.entity.News;
+import datastreams_knu.bigpicture.news.entity.Reference;
+import datastreams_knu.bigpicture.news.exception.NewsCrawlingException;
+import datastreams_knu.bigpicture.news.repository.NewsRepository;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static datastreams_knu.bigpicture.news.agent.AgentPrompt.*;
+
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class NewsCrawlingService {
 
     private final NewsCrawlingConfig newsCrawlingConfig;
+    private final WebClientUtil webClientUtil;
+    private final AiModelConfig aiModelConfig;
+    private final ObjectMapper objectMapper;
+    private final NewsRepository newsRepository;
+
     private NewsCrawlingAssistant newsCrawlingAssistant;
+    private ChatLanguageModel model;
 
     @PostConstruct
     public void init() {
-        newsCrawlingAssistant = newsCrawlingConfig.newsCrawlingAssistant();
+        this.newsCrawlingAssistant = newsCrawlingConfig.newsCrawlingAssistant();
+        this.model = aiModelConfig.openAiChatModel();
     }
 
     @Transactional
     public CrawlingResultDto crawling(String type, String keyword) {
         return newsCrawlingAssistant.execute(type, keyword);
+    }
+
+    @Transactional
+    public CrawlingResultDto dataInit(String keyword) {
+        Map<String, String> params = Map.of("&query=", URLEncoder.encode(keyword, StandardCharsets.UTF_8));
+
+        String url = createUrl(params);
+
+        CrawledNewsDto newsInfoResponse = webClientUtil.get(url, CrawledNewsDto.class);
+
+        List<String> newsIds = getNewsIds(newsInfoResponse);
+
+        List<SummarizedNewsDto> summarizedNewsList = newsIds.stream()
+            .map(id -> getSummarizedNews(keyword, id))
+            .collect(Collectors.toList());
+
+        String promptText = SUMMARIZE_MULTIPLE_NEWS_PROMPT;
+
+        String var = createVar(summarizedNewsList);
+
+        UserMessage prompt = createPrompt(promptText, var);
+
+        String summarizedNewsResponse = model.chat(prompt).aiMessage().text();
+
+        SummarizedMultipleNewsDto summarizedMultipleNews;
+        try {
+            summarizedMultipleNews = objectMapper.readValue(summarizedNewsResponse, SummarizedMultipleNewsDto.class);
+        } catch (JsonProcessingException e) {
+            throw new NewsCrawlingException("뉴스 크롤링 중 오류가 발생하였습니다: " + e.getMessage());
+        }
+
+        News news = saveNews(keyword, summarizedMultipleNews);
+        newsRepository.save(news);
+
+        return CrawlingResultDto.of(true, "뉴스 크롤링 성공");
+    }
+
+    private static String createUrl(Map<String, String> params) {
+        // 뉴스 기사 최대 20개 크롤링 (연합뉴스)
+        String baseUrl = "https://ars.yna.co.kr/api/v2/search.basic"
+            + "?page_no=1&page_size=20&scope=all&sort=weight&channel=basic_kr&cattr=A";
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        stringBuilder.append(baseUrl);
+
+        for (String s : params.keySet()) {
+            stringBuilder.append(s);
+            stringBuilder.append(params.get(s));
+        }
+
+        DateRangeDto range = getDateRange();
+        stringBuilder
+            .append("&from=")
+            .append(range.getFromDate())
+            .append("&to=")
+            .append(range.getToDate());
+
+        return stringBuilder.toString();
+    }
+
+    private static DateRangeDto getDateRange() {
+        LocalDate lastWeek = LocalDate.now().minusDays(7);
+        return DateRangeDto.of(processDate(lastWeek), processDate(LocalDate.now()));
+    }
+
+    private static String processDate(LocalDate date) {
+        return date.toString().replace("-", "");
+    }
+
+    private static List<String> getNewsIds(CrawledNewsDto response) {
+        CrawledNewsDto.YibKrA yibKrA = response.getYIB_KR_A();
+        return yibKrA.getResult().stream()
+            .map(result -> result.getCID())
+            .collect(Collectors.toList());
+    }
+
+    protected SummarizedNewsDto getSummarizedNews(String keyword, String id) {
+        SummarizedNewsDto news = getReference(id);
+        String summarizeNewsContent = summarizeNews(news.getContent(), keyword);
+        news.setContent(summarizeNewsContent);
+        return news;
+    }
+
+    protected SummarizedNewsDto getReference(String id) {
+        try {
+            String baseUrl = "https://www.yna.co.kr/view/";
+            String url = baseUrl + id;
+
+            Document doc = Jsoup.connect(url).get();
+            Elements contentElements = doc.select(".story-news p");
+
+            String content = contentElements.stream()
+                .map(Element::text)
+                .map(String::trim)
+                .filter(text -> !text.isEmpty())
+                .collect(Collectors.joining(" "));
+
+            Element dateElement = doc.selectFirst(".txt-time01");
+            String date = dateElement.text().split(" ")[0].replaceAll("[^\\d-]", "").trim();
+
+            return SummarizedNewsDto.of(url, content, date);
+        } catch (IOException e) {
+            throw new NewsCrawlingException("뉴스 크롤링 중 오류가 발생하였습니다: " + e.getMessage());
+        }
+    }
+
+    public String summarizeNews(String content, String keyword) {
+        try {
+            String promptText = keyword.equals("keyword")
+                ? SUMMARIZE_NEWS_BY_KEYWORD_PROMPT : SUMMARIZE_GENERAL_NEWS_PROMPT;
+
+            List<String> vars = List.of(content, keyword);
+
+            UserMessage prompt = createPrompt(promptText, vars);
+
+            String response = model.chat(prompt).aiMessage().text();
+
+            StringSummaryDto result = objectMapper.readValue(response, StringSummaryDto.class);
+
+            return result.getSummary();
+        } catch (JsonProcessingException e) {
+            log.info("Json 파싱 중 예외가 발생했습니다.={}", e.getMessage());
+            return "";
+        }
+    }
+
+    private String createVar(List<SummarizedNewsDto> newsList) {
+        try {
+            StringBuilder vars = new StringBuilder();
+            vars.append("[");
+            for (SummarizedNewsDto news : newsList) {
+                vars.append(objectMapper.writeValueAsString(news) + ",");
+            }
+            vars.deleteCharAt(vars.length() - 1);
+            vars.append("]");
+            return vars.toString();
+        } catch (JsonProcessingException e) {
+            log.info("Json 파싱 중 예외가 발생했습니다.={}", e.getMessage());
+            return "";
+        }
+    }
+
+    private UserMessage createPrompt(String promptText, String var) {
+        String prompt = promptText.formatted(var);
+        UserMessage userMessage = new UserMessage(prompt);
+        return userMessage;
+    }
+
+    private UserMessage createPrompt(String promptText, List<String> var) {
+        String prompt = promptText.formatted(var.toArray());
+        UserMessage userMessage = new UserMessage(prompt);
+        return userMessage;
+    }
+
+    private News saveNews(String keyword, SummarizedMultipleNewsDto result) {
+        News news = News.of(LocalDate.now(), keyword, result.getSummary());
+
+        result.getSources().stream()
+            .map(info -> Reference.of(info.getUrl()))
+            .forEach(news::addReference);
+
+        return news;
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/schedule/entity/CrawlingSeed.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/entity/CrawlingSeed.java
@@ -1,0 +1,38 @@
+package datastreams_knu.bigpicture.schedule.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class CrawlingSeed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String stockType; // korea or us
+    private String stockName; // name or ticker
+    private String stockKeyword; // news keyword
+
+    @Builder
+    public CrawlingSeed(String stockType, String stockName, String stockKeyword) {
+        this.stockType = stockType;
+        this.stockName = stockName;
+        this.stockKeyword = stockKeyword;
+    }
+
+    public static CrawlingSeed of(String stockType, String stockName, String newsKeyword) {
+        return CrawlingSeed.builder()
+            .stockType(stockType)
+            .stockName(stockName)
+            .stockKeyword(newsKeyword)
+            .build();
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/schedule/repository/CrawlingSeedRepository.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/repository/CrawlingSeedRepository.java
@@ -1,0 +1,14 @@
+package datastreams_knu.bigpicture.schedule.repository;
+
+import datastreams_knu.bigpicture.schedule.entity.CrawlingSeed;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CrawlingSeedRepository extends JpaRepository<CrawlingSeed, Long> {
+
+    List<CrawlingSeed> findAllByStockType(String stockType);
+}

--- a/src/main/java/datastreams_knu/bigpicture/schedule/scheduler/CrawlingScheduler.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/scheduler/CrawlingScheduler.java
@@ -46,4 +46,10 @@ public class CrawlingScheduler {
     public void runUSStockCrawling() {
         crawlingSchedulerService.usStockCrawling();
     }
+
+    // 새로운 키워드 크롤링(뉴스 + 주가)
+    @Scheduled(cron="0 0 4 * * *", zone = "Asia/Seoul") // 매일 오전 4시
+    public void runCrawlingSeedCrawling(){
+        crawlingSchedulerService.crawlingSeedCrawling();
+    }
 }

--- a/src/main/java/datastreams_knu/bigpicture/schedule/service/ExpireDataDeleteSchedulerService.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/service/ExpireDataDeleteSchedulerService.java
@@ -18,9 +18,9 @@ import java.time.LocalDate;
 public class ExpireDataDeleteSchedulerService {
 
     public static final int EXCHANGE_DATA_EXPIRE_MONTH = 3;
-    public static final int STOCK_DATA_EXPIRE_MONTH = 1;
     public static final int INTEREST_DATA_EXPIRE_YEAR = 1;
     public static final int NEWS_DATA_EXPIRE_DAY = 7;
+    public static final int STOCK_DATA_EXPIRE_MONTH = 1;
 
     private final ExchangeRepository exchangeRepository;
     private final KoreaInterestRepository koreaInterestRepository;

--- a/src/main/java/datastreams_knu/bigpicture/stock/agent/StockCrawlingAgent.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/agent/StockCrawlingAgent.java
@@ -34,7 +34,6 @@ public class StockCrawlingAgent {
 
     private final WebClientUtil webClientUtil;
     private final StockRepository stockRepository;
-    private final StockInfoRepository stockInfoRepository;
 
     @Value("${korea-stock.api.base-url}")
     private String koreaStockBaseUrl;

--- a/src/main/java/datastreams_knu/bigpicture/stock/service/StockCrawlingService.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/service/StockCrawlingService.java
@@ -1,17 +1,51 @@
 package datastreams_knu.bigpicture.stock.service;
 
 import datastreams_knu.bigpicture.common.dto.CrawlingResultDto;
+import datastreams_knu.bigpicture.common.dto.DateRangeDto;
+import datastreams_knu.bigpicture.common.util.WebClientUtil;
 import datastreams_knu.bigpicture.stock.agent.StockCrawlingAssistant;
+import datastreams_knu.bigpicture.stock.agent.dto.KoreaStockCrawlingDto;
+import datastreams_knu.bigpicture.stock.agent.dto.StockInfoDto;
+import datastreams_knu.bigpicture.stock.agent.dto.USStockCrawlingDto;
 import datastreams_knu.bigpicture.stock.config.StockCrawlingConfig;
+import datastreams_knu.bigpicture.stock.entity.Stock;
+import datastreams_knu.bigpicture.stock.entity.StockInfo;
+import datastreams_knu.bigpicture.stock.entity.StockType;
+import datastreams_knu.bigpicture.stock.repository.StockRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class StockCrawlingService {
+
+    public static final int MONTHS_TO_SUBTRACT = 1;
+    private final WebClientUtil webClientUtil;
+    private final StockRepository stockRepository;
+
+    @Value("${korea-stock.api.base-url}")
+    private String koreaStockBaseUrl;
+    @Value("${korea-stock.api.key}")
+    private String koreaStockApiKey;
+
+    @Value("${us-stock.api.base-url}")
+    private String usStockBaseUrl;
+    @Value("${us-stock.api.key}")
+    private String usStockApiKey;
 
     private final StockCrawlingConfig stockCrawlingConfig;
     private StockCrawlingAssistant stockCrawlingAssistant;
@@ -24,5 +58,112 @@ public class StockCrawlingService {
     @Transactional
     public CrawlingResultDto crawling(String type, String stockName) {
         return stockCrawlingAssistant.execute(type, stockName);
+    }
+
+    @Transactional
+    public CrawlingResultDto dataInit(String stockName, String stockType, String stockKeyword) {
+        List<StockInfoDto> stockInfos = getStockInfos(stockType, stockName);
+
+        Stock stock = Stock.of(stockKeyword, getStockType(stockType));
+
+        stockInfos.stream()
+            .map(info -> StockInfo.of(info.getStockPrice(), info.getStockDate()))
+            .forEach(stock::addStockInfo);
+
+        stockRepository.save(stock);
+
+        return CrawlingResultDto.of(true, "주가 크롤링 성공");
+    }
+
+    private List<StockInfoDto> getStockInfos(String stockType, String stockKeyword) {
+        List<StockInfoDto> stockInfos;
+        if (stockType.equals("korea")) {
+            String encodedStockName = encodeString(stockKeyword);
+            DateRangeDto dateRange = getKoreaStockDateRange();
+            String url = createKoreaStockUrl(encodedStockName, dateRange);
+
+            KoreaStockCrawlingDto result = webClientUtil.get(url, KoreaStockCrawlingDto.class);
+
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+            stockInfos = result.getResponse().getBody().getItems().getItem().stream()
+                .map(item -> {
+                    LocalDate stockDate = LocalDate.parse(item.getBasDt(), formatter);
+                    double stockPrice = Double.parseDouble(item.getClpr());
+                    return StockInfoDto.of(stockDate, stockPrice);
+                })
+                .sorted(Comparator.comparing(StockInfoDto::getStockDate))
+                .collect(Collectors.toList());
+        } else {
+            DateRangeDto dateRange = getUSStockDateRange();
+            String url = createUSStockUrl(stockKeyword, dateRange);
+
+            USStockCrawlingDto response = webClientUtil.get(url, USStockCrawlingDto.class);
+
+            stockInfos = response.getResults().stream()
+                .map(result -> {
+                    Instant stockInstant = Instant.ofEpochMilli(result.getT());
+                    LocalDate stockDate = stockInstant.atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
+                    return StockInfoDto.of(stockDate, result.getC());
+                })
+                .collect(Collectors.toList());
+        }
+        return stockInfos;
+    }
+
+    private StockType getStockType(String type) {
+        return type.equals("korea") ? StockType.KOREA : StockType.US;
+    }
+
+    private String createKoreaStockUrl(String stockName, DateRangeDto dateRange) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(koreaStockBaseUrl);
+        sb.append("?serviceKey=")
+            .append(koreaStockApiKey);
+        sb.append("&itmsNm=")
+            .append(stockName);
+        sb.append("&beginBasDt=")
+            .append(dateRange.getFromDate());
+        sb.append("&endBasDt=")
+            .append(dateRange.getToDate());
+        sb.append("&resultType=json")
+            .append("&numOfRows=50");
+
+        return sb.toString();
+    }
+
+    private String createUSStockUrl(String stockName, DateRangeDto dateRange) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(usStockBaseUrl);
+        sb.append("ticker/").append(stockName);
+        sb.append("/range/1/day")
+            .append("/" + dateRange.getFromDate())
+            .append("/" + dateRange.getToDate());
+        sb.append("?apiKey=")
+            .append(usStockApiKey);
+        return sb.toString();
+    }
+
+    private DateRangeDto getKoreaStockDateRange() {
+        LocalDate now = LocalDate.now();
+        LocalDate past = now.minusMonths(MONTHS_TO_SUBTRACT);
+        String nowDate = parseDate(now);
+        String pastDate = parseDate(past);
+        return DateRangeDto.of(pastDate, nowDate);
+    }
+
+    private DateRangeDto getUSStockDateRange() {
+        LocalDate now = LocalDate.now();
+        LocalDate past = now.minusMonths(MONTHS_TO_SUBTRACT);
+        String pastDate = past.toString();
+        String nowDate = now.toString();
+        return DateRangeDto.of(pastDate, nowDate);
+    }
+
+    private String parseDate(LocalDate date) {
+        return date.toString().replace("-", "");
+    }
+
+    private String encodeString(String str) {
+        return URLEncoder.encode(str, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/datastreams_knu/bigpicture/news/agent/NewsCrawlingAgentMockTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/news/agent/NewsCrawlingAgentMockTest.java
@@ -46,8 +46,7 @@ class NewsCrawlingAgentMockTest {
             webClientUtil,
             aiModelConfig,
             objectMapper,
-            newsRepository,
-            referenceRepository
+            newsRepository
         );
         spyNewsCrawlingAgent = Mockito.spy(newsCrawlingAgent);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> -


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 환율, 금리, 뉴스, 주가 초기 데이터를 세팅하였습니다.
- 환율, 금리는 직접 추가하였고 뉴스와 주가 데이터는 함께 추가되기에 새로운 키워드가 등록되면 해당 키워드를 crawling_info에 추가하고 처음 한번만 초기 데이터(주가 한달치, 뉴스 일주일치)가 생성되도록 하였습니다. 해당 작업은 매일 새벽 4시에 진행됩니다.
- 추후 리펙토링 진행 예정입니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-