### PR TITLE
hotfix: 처음 stockName 등록 시 중복으로 뉴스, 주가 데이터가 수집되는 경우 수정

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/schedule/controller/dto/RegisterCrawlingDataResponse.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/controller/dto/RegisterCrawlingDataResponse.java
@@ -1,6 +1,7 @@
 package datastreams_knu.bigpicture.schedule.controller.dto;
 
 import datastreams_knu.bigpicture.schedule.entity.CrawlingInfo;
+import datastreams_knu.bigpicture.schedule.entity.CrawlingSeed;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,11 +21,19 @@ public class RegisterCrawlingDataResponse {
         this.stockKeyword = stockKeyword;
     }
 
-    public static RegisterCrawlingDataResponse of(CrawlingInfo crawlingInfo) {
+    public static RegisterCrawlingDataResponse from(CrawlingInfo crawlingInfo) {
         return RegisterCrawlingDataResponse.builder()
             .stockType(crawlingInfo.getStockType())
             .stockName(crawlingInfo.getStockName())
             .stockKeyword(crawlingInfo.getStockKeyword())
+            .build();
+    }
+
+    public static RegisterCrawlingDataResponse from(CrawlingSeed crawlingSeed) {
+        return RegisterCrawlingDataResponse.builder()
+            .stockType(crawlingSeed.getStockType())
+            .stockName(crawlingSeed.getStockName())
+            .stockKeyword(crawlingSeed.getStockKeyword())
             .build();
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/schedule/service/CrawlingSchedulerService.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/service/CrawlingSchedulerService.java
@@ -113,10 +113,10 @@ public class CrawlingSchedulerService {
             // 주가 : 1달 동안의 주가 데이터 수집 필요
             if (crawlingSeed.getStockType().equals("korea")) {
                 String stockCrawlingTaskName = "StockCrawling-Korea/%s-%s-%s".formatted(crawlingSeed.getStockType(), crawlingSeed.getStockName(), crawlingSeed.getStockKeyword());
-                RetryExecutor.execute(() -> stockCrawlingService.dataInit(crawlingSeed.getStockName(),crawlingSeed.getStockType(), crawlingSeed.getStockKeyword()), stockCrawlingTaskName);
+                RetryExecutor.execute(() -> stockCrawlingService.dataInit(crawlingSeed.getStockName(), crawlingSeed.getStockType(), crawlingSeed.getStockKeyword()), stockCrawlingTaskName);
             } else {
                 String stockCrawlingTaskName = "StockCrawling-US/%s-%s-%s".formatted(crawlingSeed.getStockType(), crawlingSeed.getStockName(), crawlingSeed.getStockKeyword());
-                RetryExecutor.execute(() -> stockCrawlingService.dataInit(crawlingSeed.getStockName(),crawlingSeed.getStockType(), crawlingSeed.getStockKeyword()), stockCrawlingTaskName);
+                RetryExecutor.execute(() -> stockCrawlingService.dataInit(crawlingSeed.getStockName(), crawlingSeed.getStockType(), crawlingSeed.getStockKeyword()), stockCrawlingTaskName);
             }
 
             // 뉴스 : 일주일 동안의 뉴스 데이터 수집 필요
@@ -126,6 +126,9 @@ public class CrawlingSchedulerService {
             }
 
             prevStockType = crawlingSeed.getStockType();
+
+            CrawlingInfo crawlingInfo = CrawlingInfo.of(crawlingSeed.getStockType(), crawlingSeed.getStockName(), crawlingSeed.getStockKeyword());
+            crawlingInfoRepository.save(crawlingInfo);
 
             crawlingSeedRepository.delete(crawlingSeed);
         }

--- a/src/main/java/datastreams_knu/bigpicture/schedule/service/SchedulerService.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/service/SchedulerService.java
@@ -50,7 +50,7 @@ public class SchedulerService {
         // 이미 존재하는 크롤링 정보
         Optional<CrawlingInfo> findCrawlingInfo = crawlingInfoRepository.findByStockName(request.getStockName());
         if (findCrawlingInfo.isPresent()) {
-            return RegisterCrawlingDataResponse.of(findCrawlingInfo.get());
+            return RegisterCrawlingDataResponse.from(findCrawlingInfo.get());
         }
 
         String crawlingKeyword = request.getStockName();
@@ -65,11 +65,8 @@ public class SchedulerService {
         }
 
         CrawlingSeed crawlingSeed = CrawlingSeed.of(request.getStockType(), request.getStockName(), crawlingKeyword);
-        crawlingSeedRepository.save(crawlingSeed);
 
-        CrawlingInfo crawlingInfo = CrawlingInfo.of(request.getStockType(), request.getStockName(), crawlingKeyword);
-
-        return RegisterCrawlingDataResponse.of(crawlingInfoRepository.save(crawlingInfo));
+        return RegisterCrawlingDataResponse.from(crawlingSeedRepository.save(crawlingSeed));
     }
 
     private boolean isInvalidStockName(RegisterCrawlingDataServiceRequest request) {

--- a/src/test/java/datastreams_knu/bigpicture/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/schedule/controller/ScheduleControllerTest.java
@@ -39,7 +39,7 @@ class ScheduleControllerTest {
         RegisterCrawlingDataRequest request = RegisterCrawlingDataRequest.of(testStockType, "testStockName");
 
         CrawlingInfo crawlingInfo = CrawlingInfo.of(testStockType, "testStockName", "testNewsKeyword");
-        RegisterCrawlingDataResponse response = RegisterCrawlingDataResponse.of(crawlingInfo);
+        RegisterCrawlingDataResponse response = RegisterCrawlingDataResponse.from(crawlingInfo);
 
         // when
         when(schedulerService.registerCrawlingData(any()))


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 처음 stockName 등록 시 중복으로 뉴스, 주가 데이터가 수집되는 경우를 수정하였습니다.
- 현재 stockName이 처음 등록되면 crawlingInfo와 crawlingSeed에 모두 등록되어 데이터가 두번 수집되는데 데이터 초기화를 위한 crawlingSeed에서 처리 후 crawlingInfo 테이블로 저장되게 프로세스를 변경하여 중복 데이터 수집을 해결하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-