### PR TITLE
feat: 경제 데이터 조회 엔드포인트 추가

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/exchange/controller/ExchangeController.java
+++ b/src/main/java/datastreams_knu/bigpicture/exchange/controller/ExchangeController.java
@@ -1,0 +1,24 @@
+package datastreams_knu.bigpicture.exchange.controller;
+
+import datastreams_knu.bigpicture.common.domain.ApiResponse;
+import datastreams_knu.bigpicture.exchange.controller.dto.ExchangeResponse;
+import datastreams_knu.bigpicture.exchange.service.ExchangeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/api/v1/exchanges")
+@RequiredArgsConstructor
+@RestController
+public class ExchangeController {
+
+    private final ExchangeService exchangeService;
+
+    @GetMapping
+    public ApiResponse<List<ExchangeResponse>> getExchanges() {
+        return ApiResponse.ok(exchangeService.getExchanges());
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/exchange/controller/dto/ExchangeResponse.java
+++ b/src/main/java/datastreams_knu/bigpicture/exchange/controller/dto/ExchangeResponse.java
@@ -1,0 +1,32 @@
+package datastreams_knu.bigpicture.exchange.controller.dto;
+
+import datastreams_knu.bigpicture.exchange.entity.Exchange;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class ExchangeResponse {
+    private LocalDate exchangeDate;
+    private double exchangeRate;
+
+    @Builder
+    public ExchangeResponse(LocalDate exchangeDate, double exchangeRate) {
+        this.exchangeDate = exchangeDate;
+        this.exchangeRate = exchangeRate;
+    }
+
+    public static ExchangeResponse of(LocalDate date, double exchangeRate) {
+        return ExchangeResponse.builder()
+            .exchangeDate(date)
+            .exchangeRate(exchangeRate)
+            .build();
+    }
+
+    public static ExchangeResponse from(Exchange exchange) {
+        return ExchangeResponse.of(exchange.getExchangeDate(), exchange.getExchangeRate());
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/exchange/service/ExchangeService.java
+++ b/src/main/java/datastreams_knu/bigpicture/exchange/service/ExchangeService.java
@@ -1,0 +1,24 @@
+package datastreams_knu.bigpicture.exchange.service;
+
+import datastreams_knu.bigpicture.exchange.controller.dto.ExchangeResponse;
+import datastreams_knu.bigpicture.exchange.repository.ExchangeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ExchangeService {
+
+    public final ExchangeRepository exchangeRepository;
+
+    public List<ExchangeResponse> getExchanges() {
+        return exchangeRepository.findAll().stream()
+            .map(exchange -> ExchangeResponse.from(exchange))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/controller/InterestController.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/controller/InterestController.java
@@ -1,0 +1,29 @@
+package datastreams_knu.bigpicture.interest.controller;
+
+import datastreams_knu.bigpicture.common.domain.ApiResponse;
+import datastreams_knu.bigpicture.interest.controller.dto.InterestResponse;
+import datastreams_knu.bigpicture.interest.service.InterestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/api/v1/interests")
+@RequiredArgsConstructor
+@RestController
+public class InterestController {
+
+    private final InterestService interestService;
+
+    @GetMapping("/korea")
+    public ApiResponse<List<InterestResponse>> getKoreaInterests() {
+        return ApiResponse.ok(interestService.getKoreaInterests());
+    }
+
+    @GetMapping("/us")
+    public ApiResponse<List<InterestResponse>> getUSInterests() {
+        return ApiResponse.ok(interestService.getUSInterests());
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/controller/dto/InterestResponse.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/controller/dto/InterestResponse.java
@@ -1,0 +1,37 @@
+package datastreams_knu.bigpicture.interest.controller.dto;
+
+import datastreams_knu.bigpicture.interest.entity.KoreaInterest;
+import datastreams_knu.bigpicture.interest.entity.USInterest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class InterestResponse {
+    private LocalDate interestDate;
+    private double interestRate;
+
+    @Builder
+    public InterestResponse(LocalDate interestDate, double interestRate) {
+        this.interestDate = interestDate;
+        this.interestRate = interestRate;
+    }
+
+    public static InterestResponse of(LocalDate interestDate, double interestRate) {
+        return InterestResponse.builder()
+            .interestDate(interestDate)
+            .interestRate(interestRate)
+            .build();
+    }
+
+    public static InterestResponse from(KoreaInterest interest) {
+        return InterestResponse.of(interest.getInterestDate(), interest.getInterestRate());
+    }
+
+    public static InterestResponse from(USInterest interest) {
+        return InterestResponse.of(interest.getInterestDate(), interest.getInterestRate());
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/interest/service/InterestService.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/service/InterestService.java
@@ -1,0 +1,32 @@
+package datastreams_knu.bigpicture.interest.service;
+
+import datastreams_knu.bigpicture.interest.controller.dto.InterestResponse;
+import datastreams_knu.bigpicture.interest.repository.KoreaInterestRepository;
+import datastreams_knu.bigpicture.interest.repository.USInterestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class InterestService {
+
+    private final KoreaInterestRepository koreaInterestRepository;
+    private final USInterestRepository usInterestRepository;
+
+    public List<InterestResponse> getKoreaInterests() {
+        return koreaInterestRepository.findAll().stream()
+            .map(interest -> InterestResponse.from(interest))
+            .collect(Collectors.toList());
+    }
+
+    public List<InterestResponse> getUSInterests() {
+        return usInterestRepository.findAll().stream()
+            .map(interest -> InterestResponse.from(interest))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/stock/agent/StockCrawlingAgent.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/agent/StockCrawlingAgent.java
@@ -9,7 +9,6 @@ import datastreams_knu.bigpicture.stock.agent.dto.USStockCrawlingDto;
 import datastreams_knu.bigpicture.stock.entity.Stock;
 import datastreams_knu.bigpicture.stock.entity.StockInfo;
 import datastreams_knu.bigpicture.stock.entity.StockType;
-import datastreams_knu.bigpicture.stock.repository.StockInfoRepository;
 import datastreams_knu.bigpicture.stock.repository.StockRepository;
 import dev.langchain4j.agent.tool.Tool;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +21,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -70,6 +70,10 @@ public class StockCrawlingAgent {
         String url = createUSStockUrl(stockName, dateRange);
 
         USStockCrawlingDto response = webClientUtil.get(url, USStockCrawlingDto.class);
+
+        if (response.getResults() == null) {
+            return Collections.emptyList();
+        }
 
         return response.getResults().stream()
             .map(result -> {

--- a/src/main/java/datastreams_knu/bigpicture/stock/controller/StockController.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/controller/StockController.java
@@ -1,0 +1,25 @@
+package datastreams_knu.bigpicture.stock.controller;
+
+import datastreams_knu.bigpicture.common.domain.ApiResponse;
+import datastreams_knu.bigpicture.stock.controller.dto.StockResponse;
+import datastreams_knu.bigpicture.stock.service.StockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stocks")
+@RestController
+public class StockController {
+
+    private final StockService stockService;
+
+    @GetMapping
+    public ApiResponse<List<StockResponse>> getStocks(@RequestParam("stockName") String stockName) {
+        return ApiResponse.ok(stockService.getStocks(stockName));
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/stock/controller/dto/StockResponse.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/controller/dto/StockResponse.java
@@ -1,0 +1,32 @@
+package datastreams_knu.bigpicture.stock.controller.dto;
+
+import datastreams_knu.bigpicture.stock.entity.StockInfo;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class StockResponse {
+    private LocalDate stockDate;
+    private double stockPrice;
+
+    @Builder
+    public StockResponse(LocalDate stockDate, double stockPrice) {
+        this.stockDate = stockDate;
+        this.stockPrice = stockPrice;
+    }
+
+    public static StockResponse of(LocalDate stockDate, double stockPrice) {
+        return StockResponse.builder()
+            .stockDate(stockDate)
+            .stockPrice(stockPrice)
+            .build();
+    }
+
+    public static StockResponse from(StockInfo stockInfo) {
+        return StockResponse.of(stockInfo.getStockDate(), stockInfo.getStockPrice());
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/stock/service/StockService.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/service/StockService.java
@@ -1,0 +1,28 @@
+package datastreams_knu.bigpicture.stock.service;
+
+import datastreams_knu.bigpicture.stock.controller.dto.StockResponse;
+import datastreams_knu.bigpicture.stock.entity.Stock;
+import datastreams_knu.bigpicture.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class StockService {
+
+    private final StockRepository stockRepository;
+
+    public List<StockResponse> getStocks(String stockName) {
+        Stock stock = stockRepository.findByName(stockName)
+            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 stockName 입니다."));
+
+        return stock.getStockInfos().stream()
+            .map(stockInfo -> StockResponse.from(stockInfo))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/datastreams_knu/bigpicture/exchange/controller/ExchangeControllerTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/exchange/controller/ExchangeControllerTest.java
@@ -1,0 +1,45 @@
+package datastreams_knu.bigpicture.exchange.controller;
+
+import datastreams_knu.bigpicture.exchange.service.ExchangeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ExchangeController.class)
+class ExchangeControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    ExchangeService exchangeService;
+
+    @DisplayName("모든 환율 데이터들을 가져온다.")
+    @Test
+    void getExchanges() throws Exception {
+        // given // when
+        when(exchangeService.getExchanges())
+            .thenReturn(Collections.emptyList());
+
+        // then
+        mockMvc.perform(
+                get("/api/v1/exchanges")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"));
+    }
+}

--- a/src/test/java/datastreams_knu/bigpicture/exchange/service/ExchangeServiceTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/exchange/service/ExchangeServiceTest.java
@@ -1,0 +1,46 @@
+package datastreams_knu.bigpicture.exchange.service;
+
+import datastreams_knu.bigpicture.exchange.controller.dto.ExchangeResponse;
+import datastreams_knu.bigpicture.exchange.entity.Exchange;
+import datastreams_knu.bigpicture.exchange.repository.ExchangeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ExchangeServiceTest {
+
+    @Autowired
+    ExchangeService exchangeService;
+    @Autowired
+    ExchangeRepository exchangeRepository;
+
+    @DisplayName("모든 환율 데이터를 가져온다.")
+    @Test
+    void getAllExchanges() {
+        // given
+        LocalDate now = LocalDate.now();
+
+        List<Exchange> exchanges = List.of(
+            Exchange.of(now, 0.01),
+            Exchange.of(now, 0.02),
+            Exchange.of(now, 0.03)
+        );
+
+        exchangeRepository.saveAll(exchanges);
+
+        // when
+        List<ExchangeResponse> findExchanges = exchangeService.getExchanges();
+
+        // then
+        assertThat(findExchanges).hasSize(3);
+        assertThat(findExchanges.get(0)).isInstanceOf(ExchangeResponse.class);
+    }
+
+}

--- a/src/test/java/datastreams_knu/bigpicture/interest/controller/InterestControllerTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/interest/controller/InterestControllerTest.java
@@ -1,0 +1,66 @@
+package datastreams_knu.bigpicture.interest.controller;
+
+import datastreams_knu.bigpicture.interest.service.InterestService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = InterestController.class)
+class InterestControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    InterestService interestService;
+
+    @DisplayName("모든 한국 금리 데이터들을 가져온다.")
+    @Test
+    void getKoreaInterests() throws Exception {
+        // given // when
+        when(interestService.getKoreaInterests())
+            .thenReturn(Collections.emptyList());
+
+        // then
+        mockMvc.perform(
+                get("/api/v1/interests/korea")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("모든 미국 금리 데이터들을 가져온다.")
+    @Test
+    void getUSInterests() throws Exception {
+        // given // when
+        when(interestService.getUSInterests())
+            .thenReturn(Collections.emptyList());
+
+        // then
+        mockMvc.perform(
+                get("/api/v1/interests/us")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+}

--- a/src/test/java/datastreams_knu/bigpicture/interest/service/InterestServiceTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/interest/service/InterestServiceTest.java
@@ -1,0 +1,72 @@
+package datastreams_knu.bigpicture.interest.service;
+
+import datastreams_knu.bigpicture.interest.controller.dto.InterestResponse;
+import datastreams_knu.bigpicture.interest.entity.KoreaInterest;
+import datastreams_knu.bigpicture.interest.entity.USInterest;
+import datastreams_knu.bigpicture.interest.repository.KoreaInterestRepository;
+import datastreams_knu.bigpicture.interest.repository.USInterestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class InterestServiceTest {
+
+    @Autowired
+    InterestService interestService;
+    @Autowired
+    KoreaInterestRepository koreaInterestRepository;
+    @Autowired
+    USInterestRepository usInterestRepository;
+
+    @DisplayName("모든 한국 금리 데이터를 가져온다.")
+    @Test
+    void getAllKoreaInterests() {
+        // given
+        LocalDate now = LocalDate.now();
+
+        List<KoreaInterest> koreaInterests = List.of(
+            KoreaInterest.of(now, 0.01),
+            KoreaInterest.of(now, 0.02),
+            KoreaInterest.of(now, 0.03)
+        );
+
+        koreaInterestRepository.saveAll(koreaInterests);
+
+        // when
+        List<InterestResponse> findKoreaInterests = interestService.getKoreaInterests();
+
+        // then
+        assertThat(findKoreaInterests).hasSize(3);
+        assertThat(findKoreaInterests.get(0)).isInstanceOf(InterestResponse.class);
+    }
+
+    @DisplayName("모든 미국 금리 데이터를 가져온다.")
+    @Test
+    void getAllUSInterests() {
+        // given
+        LocalDate now = LocalDate.now();
+
+        List<USInterest> usInterests = List.of(
+            USInterest.of(now, 0.01),
+            USInterest.of(now, 0.02),
+            USInterest.of(now, 0.03)
+        );
+
+        usInterestRepository.saveAll(usInterests);
+
+        // when
+        List<InterestResponse> findUSInterests = interestService.getUSInterests();
+
+        // then
+        assertThat(findUSInterests).hasSize(3);
+        assertThat(findUSInterests.get(0)).isInstanceOf(InterestResponse.class);
+    }
+
+}

--- a/src/test/java/datastreams_knu/bigpicture/stock/controller/StockControllerTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/stock/controller/StockControllerTest.java
@@ -1,0 +1,48 @@
+package datastreams_knu.bigpicture.stock.controller;
+
+import datastreams_knu.bigpicture.stock.service.StockService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = StockController.class)
+class StockControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    StockService stockService;
+
+    @DisplayName("모든 주가 데이터들을 가져온다.")
+    @Test
+    void getStocks() throws Exception {
+        // given // when
+        when(stockService.getStocks(any()))
+            .thenReturn(Collections.emptyList());
+
+        // then
+        mockMvc.perform(
+                get("/api/v1/stocks")
+                    .param("stockName", "test")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.status").value("OK"))
+            .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+}

--- a/src/test/java/datastreams_knu/bigpicture/stock/repository/StockRepositoryTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/stock/repository/StockRepositoryTest.java
@@ -1,6 +1,7 @@
 package datastreams_knu.bigpicture.stock.repository;
 
 import datastreams_knu.bigpicture.stock.entity.Stock;
+import datastreams_knu.bigpicture.stock.entity.StockInfo;
 import datastreams_knu.bigpicture.stock.entity.StockType;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,12 +24,9 @@ class StockRepositoryTest {
     @Autowired
     StockInfoRepository stockInfoRepository;
 
-    @Autowired
-    EntityManager em;
-
     @DisplayName("StockName에 해당하는 stock을 찾는다.")
     @Test
-    void FindByStockNameTest() {
+    void findByStockNameTest() {
         // given
         String stockName = "testName";
         StockType stockType = StockType.KOREA;

--- a/src/test/java/datastreams_knu/bigpicture/stock/service/StockServiceTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/stock/service/StockServiceTest.java
@@ -1,0 +1,45 @@
+package datastreams_knu.bigpicture.stock.service;
+
+import datastreams_knu.bigpicture.stock.controller.dto.StockResponse;
+import datastreams_knu.bigpicture.stock.entity.Stock;
+import datastreams_knu.bigpicture.stock.entity.StockInfo;
+import datastreams_knu.bigpicture.stock.entity.StockType;
+import datastreams_knu.bigpicture.stock.repository.StockRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class StockServiceTest {
+
+    @Autowired
+    StockService stockService;
+    @Autowired
+    StockRepository stockRepository;
+
+    @DisplayName("모든 주가 데이터들을 가져온다.")
+    @Test
+    void getAllStockInfos() {
+        // given
+        String stockName = "testStock";
+
+        Stock stock = Stock.of(stockName, StockType.KOREA);
+        stock.addStockInfo(StockInfo.of(0.01, LocalDate.now()
+        ));
+
+        stockRepository.save(stock);
+
+        // when
+        List<StockResponse> findStocks = stockService.getStocks(stockName);
+
+        // then
+        assertThat(findStocks).hasSize(1);
+        assertThat(findStocks.get(0)).isInstanceOf(StockResponse.class);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 환율, 금리, 주가 조회 엔드포인트 추가하였습니다.
- 미국 주가 크롤링 관련 NPE 방지용 로직 추가하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
stockName(주식 이름, ticker)과 stockKeyword(뉴스 크롤링 시 사용)가 혼용되어 사용되고 있습니다. 바로 수정해서 pr 올릴 예정입니다.

## ✏ Git Close
> close #-