### PR TITLE
refactor: stockName과 stockKeyword가 혼용되는 문제 해결 및 리펙토링

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/report/service/ReportService.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/service/ReportService.java
@@ -125,7 +125,7 @@ public class ReportService {
                 .collect(Collectors.toList());
             String newsListData = parseToString(newsList);
 
-            Stock stock = stockRepository.findByName(keyword)
+            Stock stock = stockRepository.findByStockName(keyword)
                 .orElseThrow(IllegalArgumentException::new);
             List<StockPromptInputDto> stockInfos = stock.getStockInfos().stream()
                 .map(stockInfo -> StockPromptInputDto.from(stockInfo))

--- a/src/main/java/datastreams_knu/bigpicture/schedule/service/CrawlingSchedulerService.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/service/CrawlingSchedulerService.java
@@ -59,7 +59,7 @@ public class CrawlingSchedulerService {
         List<CrawlingInfo> crawlingInfos = crawlingInfoRepository.findAllByStockType("korea");
         for (CrawlingInfo info : crawlingInfos) {
             String stockCrawlingTaskName = "StockCrawling-Korea/%s-%s-%s".formatted(info.getStockType(), info.getStockName(), info.getStockKeyword());
-            RetryExecutor.execute(() -> stockCrawlingService.crawling(info.getStockType(), info.getStockKeyword()), stockCrawlingTaskName);
+            RetryExecutor.execute(() -> stockCrawlingService.crawling(info.getStockType(), info.getStockName()), stockCrawlingTaskName);
         }
     }
 
@@ -70,7 +70,7 @@ public class CrawlingSchedulerService {
             // api 호출 제한을 피하기 위한 대기 시간(60초)
             try {
                 String stockCrawlingTaskName = "StockCrawling-US/%s-%s-%s".formatted(info.getStockType(), info.getStockName(), info.getStockKeyword());
-                RetryExecutor.execute(() -> stockCrawlingService.crawling(info.getStockType(), info.getStockKeyword()), stockCrawlingTaskName);
+                RetryExecutor.execute(() -> stockCrawlingService.crawling(info.getStockType(), info.getStockName()), stockCrawlingTaskName);
                 Thread.sleep(60 * 1000);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
@@ -113,10 +113,10 @@ public class CrawlingSchedulerService {
             // 주가 : 1달 동안의 주가 데이터 수집 필요
             if (crawlingSeed.getStockType().equals("korea")) {
                 String stockCrawlingTaskName = "StockCrawling-Korea/%s-%s-%s".formatted(crawlingSeed.getStockType(), crawlingSeed.getStockName(), crawlingSeed.getStockKeyword());
-                RetryExecutor.execute(() -> stockCrawlingService.dataInit(crawlingSeed.getStockName(), crawlingSeed.getStockType(), crawlingSeed.getStockKeyword()), stockCrawlingTaskName);
+                RetryExecutor.execute(() -> stockCrawlingService.dataInit(crawlingSeed.getStockName(), crawlingSeed.getStockType()), stockCrawlingTaskName);
             } else {
                 String stockCrawlingTaskName = "StockCrawling-US/%s-%s-%s".formatted(crawlingSeed.getStockType(), crawlingSeed.getStockName(), crawlingSeed.getStockKeyword());
-                RetryExecutor.execute(() -> stockCrawlingService.dataInit(crawlingSeed.getStockName(), crawlingSeed.getStockType(), crawlingSeed.getStockKeyword()), stockCrawlingTaskName);
+                RetryExecutor.execute(() -> stockCrawlingService.dataInit(crawlingSeed.getStockName(), crawlingSeed.getStockType()), stockCrawlingTaskName);
             }
 
             // 뉴스 : 일주일 동안의 뉴스 데이터 수집 필요

--- a/src/main/java/datastreams_knu/bigpicture/stock/agent/StockCrawlingAgent.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/agent/StockCrawlingAgent.java
@@ -86,7 +86,7 @@ public class StockCrawlingAgent {
 
     @Tool("크롤링 된 주가 데이터를 주식의 'type'과 'stockName'과 함께 DB에 저장하고 처리 성공 여부를 반환합니다.")
     public CrawlingResultDto saveStock(String type, String stockName, List<StockInfoDto> stockInfos) {
-        Stock stock = stockRepository.findByName(stockName)
+        Stock stock = stockRepository.findByStockName(stockName)
             .orElse(Stock.of(stockName, getStockType(type)));
 
         stockInfos.stream()

--- a/src/main/java/datastreams_knu/bigpicture/stock/entity/Stock.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/entity/Stock.java
@@ -18,7 +18,7 @@ public class Stock {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    private String stockName;
 
     @Enumerated(EnumType.STRING)
     private StockType stockType;
@@ -36,14 +36,14 @@ public class Stock {
     }
 
     @Builder
-    public Stock(String name, StockType stockType) {
-        this.name = name;
+    public Stock(String stockName, StockType stockType) {
+        this.stockName = stockName;
         this.stockType = stockType;
     }
 
-    public static Stock of(String name, StockType stockType) {
+    public static Stock of(String stockName, StockType stockType) {
         return Stock.builder()
-            .name(name)
+            .stockName(stockName)
             .stockType(stockType)
             .build();
     }

--- a/src/main/java/datastreams_knu/bigpicture/stock/repository/StockRepository.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/repository/StockRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
 
-    Optional<Stock> findByName(String name);
+    Optional<Stock> findByStockName(String stockName);
 }

--- a/src/main/java/datastreams_knu/bigpicture/stock/service/StockCrawlingService.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/service/StockCrawlingService.java
@@ -61,10 +61,10 @@ public class StockCrawlingService {
     }
 
     @Transactional
-    public CrawlingResultDto dataInit(String stockName, String stockType, String stockKeyword) {
+    public CrawlingResultDto dataInit(String stockName, String stockType) {
         List<StockInfoDto> stockInfos = getStockInfos(stockType, stockName);
 
-        Stock stock = Stock.of(stockKeyword, getStockType(stockType));
+        Stock stock = Stock.of(stockName, getStockType(stockType));
 
         stockInfos.stream()
             .map(info -> StockInfo.of(info.getStockPrice(), info.getStockDate()))

--- a/src/main/java/datastreams_knu/bigpicture/stock/service/StockService.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/service/StockService.java
@@ -18,7 +18,7 @@ public class StockService {
     private final StockRepository stockRepository;
 
     public List<StockResponse> getStocks(String stockName) {
-        Stock stock = stockRepository.findByName(stockName)
+        Stock stock = stockRepository.findByStockName(stockName)
             .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 stockName 입니다."));
 
         return stock.getStockInfos().stream()

--- a/src/test/java/datastreams_knu/bigpicture/stock/agent/StockCrawlingAgentTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/stock/agent/StockCrawlingAgentTest.java
@@ -41,7 +41,7 @@ class StockCrawlingAgentTest {
         // when
         CrawlingResultDto result = stockCrawlingAgent.saveStock(type, stockName, stockInfoDtoList);
 
-        Optional<Stock> findStock = stockRepository.findByName(stockName);
+        Optional<Stock> findStock = stockRepository.findByStockName(stockName);
 
         // then
         assertThat(result.getResult()).isTrue();

--- a/src/test/java/datastreams_knu/bigpicture/stock/repository/StockRepositoryTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/stock/repository/StockRepositoryTest.java
@@ -1,16 +1,13 @@
 package datastreams_knu.bigpicture.stock.repository;
 
 import datastreams_knu.bigpicture.stock.entity.Stock;
-import datastreams_knu.bigpicture.stock.entity.StockInfo;
 import datastreams_knu.bigpicture.stock.entity.StockType;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,7 +32,7 @@ class StockRepositoryTest {
         stockRepository.save(stock);
 
         // when
-        Optional<Stock> findStock = stockRepository.findByName(stockName);
+        Optional<Stock> findStock = stockRepository.findByStockName(stockName);
 
         // then
         assertThat(findStock).isPresent();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> -


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- stockName(주식 이름, ticker)과 stockKeyword(뉴스 크롤링 시 사용)가 혼용되고 있었습니다.
- 이에 뉴스에서는 stockKeyword, 주가에서는 stockName으로 사용하도록 수정하였습니다.
- Stock 엔티티의 name 필드를 stockName으로 변경하였습니다. (운영 DB에도 반영 완료하였습니다.)

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -

## ⏰ 현재 버그
-

## ✏ Git Close
> close #-