### PR TITLE
hotfix: 레포트 생성 시 주가 데이터 가져올 때 stockName 전달하도록 수정

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/report/service/ReportService.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/service/ReportService.java
@@ -125,7 +125,7 @@ public class ReportService {
                 .collect(Collectors.toList());
             String newsListData = parseToString(newsList);
 
-            Stock stock = stockRepository.findByStockName(keyword)
+            Stock stock = stockRepository.findByStockName(stockName)
                 .orElseThrow(IllegalArgumentException::new);
             List<StockPromptInputDto> stockInfos = stock.getStockInfos().stream()
                 .map(stockInfo -> StockPromptInputDto.from(stockInfo))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=update
 
 # API BASE-URLS
 ecos.api.base-url=https://ecos.bok.or.kr/api/StatisticSearch/


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 레포트 생성 시 주가 데이터 가져올 때 stockKeyword가 전달되도록 되어 있어 주식 기반 레포트 생성 시 400이 반환되는 버그가 존재했습니다
- 레포트 생성 시 주가 데이터 가져올 때 stockName을 전달하도록 수정하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-