### PR TITLE
feat: spring, python 서버 테스트용 엔드포인트 추가

### DIFF
--- a/.github/workflows/docker-push-deployment.yml
+++ b/.github/workflows/docker-push-deployment.yml
@@ -34,6 +34,7 @@ jobs:
           fred.api.key=${{ secrets.FRED_API_KEY }}
           korea-stock.api.key=${{ secrets.KOREA_STOCK_API_KEY }}
           us-stock.api.key=${{ secrets.US_STOCK_API_KEY }}
+          python.server.url=${{ secrets.PYTHON_SERVER_URL }}
           EOF
 
       - name: 📄 Generate firebase_service_key.json
@@ -58,6 +59,7 @@ jobs:
           fred.api.key=${{ secrets.FRED_API_KEY }}
           korea-stock.api.key=${{ secrets.KOREA_STOCK_API_KEY }}
           us-stock.api.key=${{ secrets.US_STOCK_API_KEY }}
+          python.server.url=${{ secrets.PYTHON_SERVER_URL }}
           EOF
 
       - name: 🛠️ Set up Gradle

--- a/src/main/java/datastreams_knu/bigpicture/common/controller/TestController.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/controller/TestController.java
@@ -1,0 +1,38 @@
+package datastreams_knu.bigpicture.common.controller;
+
+import datastreams_knu.bigpicture.common.controller.dto.PythonTestDto;
+import datastreams_knu.bigpicture.common.domain.ApiResponse;
+import datastreams_knu.bigpicture.common.util.WebClientUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/test")
+@RestController
+@Tag(name = "테스트", description = "테스트용 API")
+public class TestController {
+
+    private final WebClientUtil webClientUtil;
+
+    @Value("${python.server.url}")
+    private String pythonServerUrl;
+
+    @GetMapping("/spring")
+    @Operation(summary = "테스트 엔드포인트 - spring server", description = "스프링 서버 테스트용 엔드포인트")
+    public ApiResponse<String> getTestSpring() {
+        return ApiResponse.ok("ok");
+    }
+
+    @GetMapping("/python")
+    @Operation(summary = "테스트 엔드포인트 - python server", description = "파이썬 서버 테스트용 엔드포인트")
+    public ApiResponse<String> getTestPython() {
+        PythonTestDto res = webClientUtil.get("http://localhost:8000", PythonTestDto.class);
+        return ApiResponse.ok(res.getStatus());
+    }
+
+}

--- a/src/main/java/datastreams_knu/bigpicture/common/controller/dto/PythonTestDto.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/controller/dto/PythonTestDto.java
@@ -1,0 +1,10 @@
+package datastreams_knu.bigpicture.common.controller.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PythonTestDto {
+    private String status;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> -


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- spring, python 서버 테스트용 엔드포인트를 추가하였습니다.
- 해외 주식 주가 관련 코드를 polygon.io에서 커스텀 api로 이전할 예정입니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-