### PR TITLE
refactor: news alert response 항목 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ src/main/resources/application-secret.properties
 src/test/resources/application-test.properties
 
 src/main/resources/firebase/
+
+.DS_Store

--- a/src/main/java/datastreams_knu/bigpicture/alert/controller/AlertController.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/controller/AlertController.java
@@ -37,4 +37,9 @@ public class AlertController {
     public ApiResponse<String> deleteWatchlist(@RequestBody DeleteWatchlistRequest request) {
         return ApiResponse.ok(alertService.deleteWatchlist(request.toServiceRequest()));
     }
+
+    @GetMapping("/test")
+    public ApiResponse<String> testFcm() {
+        return ApiResponse.ok(alertService.sendTestFcmRequest());
+    }
 }

--- a/src/main/java/datastreams_knu/bigpicture/alert/service/dto/AlertNewsResponse.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/service/dto/AlertNewsResponse.java
@@ -17,40 +17,37 @@ public class AlertNewsResponse {
     public LocalDateTime newsLocalDateTime;
     public String url;
     public String keyword;
-    public String content;
     public String title;
-    public String writer;
-    public String thumbnailUrl;
 
     @Builder
-    public AlertNewsResponse(LocalDateTime newsLocalDateTime, String url, String keyword, String content, String title, String writer, String thumbnailUrl) {
+    public AlertNewsResponse(LocalDateTime newsLocalDateTime, String url, String keyword, String title) {
         this.newsLocalDateTime = newsLocalDateTime;
         this.url = url;
         this.keyword = keyword;
-        this.content = content;
         this.title = title;
-        this.writer = writer;
-        this.thumbnailUrl = thumbnailUrl;
     }
 
-    public static AlertNewsResponse from(Result result, String summarizedContent) {
+    public static AlertNewsResponse of(LocalDateTime newsLocalDateTime, String url, String keyword, String title) {
+        return AlertNewsResponse.builder()
+                .newsLocalDateTime(newsLocalDateTime)
+                .url(url)
+                .keyword(keyword)
+                .title(title)
+                .build();
+    }
+
+    public static AlertNewsResponse from(Result result) {
         String dateStr = result.getDATETIME();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
         LocalDateTime dateTime = LocalDateTime.parse(dateStr, formatter);
 
         String url = "https://www.yna.co.kr/view/" + result.getCID();
 
-        String thumbnailBaseUrl = "https://img4.yna.co.kr";
-        String thumbnailUrl = thumbnailBaseUrl + result.getTHUMBNAIL().replace("T.jpg", "P4.jpg");
-
-        return AlertNewsResponse.builder()
-                .newsLocalDateTime(dateTime)
-                .url(url)
-                .keyword(result.getKEYWORD().replace("\r\n", ", "))
-                .content(summarizedContent)
-                .title(result.getEDIT_TITLE())
-                .writer(result.getWRITER_NAME())
-                .thumbnailUrl(thumbnailUrl)
-                .build();
+        return AlertNewsResponse.of(
+                dateTime,
+                url,
+                result.getKEYWORD().replace("\r\n", ", "),
+                result.getEDIT_TITLE()
+        );
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/alert/service/dto/CrawledNewsDto.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/service/dto/CrawledNewsDto.java
@@ -28,9 +28,6 @@ public class CrawledNewsDto {
         public String DATETIME;
         public String CID;
         public String KEYWORD;
-        public String BODY;
         public String EDIT_TITLE;
-        public String WRITER_NAME;
-        public String THUMBNAIL;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- news alert response 항목을 수정하였습니다.
> newsLocalDateTime, url, keyword, title
- fcm 테스트용 엔드포인트 추가. get 요청 넣으면 fcm request 전송 (스웨거에서 사용)

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-