### PR TITLE
hotfix: fcm resource 정리 코드 추가

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/alert/service/FcmService.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/service/FcmService.java
@@ -7,10 +7,7 @@ import com.google.common.net.HttpHeaders;
 import datastreams_knu.bigpicture.alert.service.dto.FcmRequest;
 import datastreams_knu.bigpicture.common.exception.ObjectMapperException;
 import lombok.RequiredArgsConstructor;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
+import okhttp3.*;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
@@ -40,8 +37,10 @@ public class FcmService {
                 .addHeader(HttpHeaders.CONTENT_TYPE, MEDIA_TYPE)
                 .build();
 
-        try {
-            client.newCall(request).execute();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("FCM 요청 실패: " + response.code() + " - " + response.message());
+            }
         } catch (IOException e) {
             throw new UncheckedIOException("FCM 메시지 전송 중 I/O 오류가 발생했습니다", e);
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #57


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- fcm 요청 후에 OkHttpClient가 https://fcm.googleapis.com/ 에 대한 HTTP 연결을 닫지 않고 방치하여 연결 leak가 발생하고 있었습니다.
- `try-with-resources`를 사용하여 요청 처리 후 자동으로 요청이 닫히게 하였습니다.
```java
public void sendMessageTo(String fcmToken, String title, String body) {
    String message = makeMessage(fcmToken, title, body);

    OkHttpClient client = new OkHttpClient();
    RequestBody requestBody = RequestBody.create(message,
            MediaType.get(MEDIA_TYPE));
    Request request = new Request.Builder()
            .url(API_URL)
            .post(requestBody)
            .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
            .addHeader(HttpHeaders.CONTENT_TYPE, MEDIA_TYPE)
            .build();

    try (Response response = client.newCall(request).execute()) {
        if (!response.isSuccessful()) {
            throw new IOException("FCM 요청 실패: " + response.code() + " - " + response.message());
        }
    } catch (IOException e) {
        throw new UncheckedIOException("FCM 메시지 전송 중 I/O 오류가 발생했습니다", e);
    }
}
```

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
현재 fcm 푸시 알림 전송이 이루어지지 않고 있습니다. 해당 요청 정리 코드 추가 시 정상적으로 이루어 질 것 같습니다.

## ✏ Git Close
> close #57