### PR TITLE
hotfix: fcm 전송 중 오류 발생하는 토큰 삭제 후 진행하는 로직 추가

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/alert/repository/MemberRepository.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/repository/MemberRepository.java
@@ -18,4 +18,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             WHERE m.id = :id
             """)
     Optional<Member> findWithWatchlistsById(@Param("id") String id);
+
+    void deleteByFcmToken(String fcmToken);
 }

--- a/src/main/java/datastreams_knu/bigpicture/alert/service/FcmService.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/service/FcmService.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.net.HttpHeaders;
+import datastreams_knu.bigpicture.alert.repository.MemberRepository;
 import datastreams_knu.bigpicture.alert.service.dto.FcmRequest;
 import datastreams_knu.bigpicture.common.exception.ObjectMapperException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class FcmService {
@@ -22,6 +25,7 @@ public class FcmService {
     public final String MEDIA_TYPE = "application/json; charset=utf-8";
     private final String API_URL = "https://fcm.googleapis.com/v1/projects/bigpicture-c2798/messages:send";
 
+    private final MemberRepository memberRepository;
     private final ObjectMapper objectMapper;
 
     public void sendMessageTo(String fcmToken, String title, String body) {
@@ -42,7 +46,8 @@ public class FcmService {
                 throw new IOException("FCM 요청 실패: " + response.code() + " - " + response.message());
             }
         } catch (IOException e) {
-            throw new UncheckedIOException("FCM 메시지 전송 중 I/O 오류가 발생했습니다", e);
+            log.warn("FCM Error Log | fcmToken: {} | message: {}", fcmToken, e.getMessage());
+            memberRepository.deleteByFcmToken(fcmToken);
         }
     }
 

--- a/src/test/java/datastreams_knu/bigpicture/alert/repository/MemberRepositoryTest.java
+++ b/src/test/java/datastreams_knu/bigpicture/alert/repository/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package datastreams_knu.bigpicture.alert.repository;
 
 import datastreams_knu.bigpicture.alert.entity.Member;
 import datastreams_knu.bigpicture.alert.service.AlertService;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,8 @@ class MemberRepositoryTest {
     WatchlistRepository watchlistRepository;
     @Autowired
     AlertService alertService;
+    @Autowired
+    EntityManager em;
 
     @DisplayName("MemberRepository에서 String으로 정의한 id로 Member를 찾아온다.")
     @Test
@@ -40,5 +43,26 @@ class MemberRepositoryTest {
         assertThat(findMember).isPresent();
         assertThat(findMember.get().getId()).isEqualTo(id);
         assertThat(findMember.get().getFcmToken()).isEqualTo(fcmToken);
+    }
+
+    @DisplayName("MemberRepository에서 FcmToken으로 Member를 삭제한다.")
+    @Test
+    void deleteByFcmTokenTest() {
+        // given
+        String id = "uuid";
+        String fcmToken = "fcmToken";
+        Member member = Member.of(id, fcmToken);
+
+        memberRepository.save(member);
+
+        // when
+        memberRepository.deleteByFcmToken(fcmToken);
+
+        em.flush();
+        em.clear();
+
+        // then
+        Optional<Member> findMember = memberRepository.findById(id);
+        assertThat(findMember).isEmpty();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- fcm 전송 중 유효하지 않은 토큰 오류가 발생하면 해당 부분에서 멈추도록 구현이 되어있었습니다.
- 해당 부분에 대해 유효하지 않은 토큰 삭제 후 계속 진행되게 수정하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-