### PR TITLE
hotfix: stockKeyword로 파싱이 필요한 부분 resolver 대신 tickerParser 적용

### DIFF
--- a/src/main/java/datastreams_knu/bigpicture/alert/service/AlertService.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/service/AlertService.java
@@ -7,10 +7,13 @@ import datastreams_knu.bigpicture.alert.entity.Watchlist;
 import datastreams_knu.bigpicture.alert.repository.MemberRepository;
 import datastreams_knu.bigpicture.alert.repository.MemberWatchlistRepository;
 import datastreams_knu.bigpicture.alert.repository.WatchlistRepository;
-import datastreams_knu.bigpicture.alert.service.dto.*;
+import datastreams_knu.bigpicture.alert.service.dto.AlertNewsResponse;
+import datastreams_knu.bigpicture.alert.service.dto.DeleteWatchlistServiceRequest;
+import datastreams_knu.bigpicture.alert.service.dto.RegisterFcmTokenServiceRequest;
+import datastreams_knu.bigpicture.alert.service.dto.RegisterWatchlistServiceRequest;
 import datastreams_knu.bigpicture.common.exception.ObjectMapperException;
-import datastreams_knu.bigpicture.common.util.StockKeywordResolver;
 import datastreams_knu.bigpicture.common.util.StockNameValidator;
+import datastreams_knu.bigpicture.common.util.TickerParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +32,7 @@ public class AlertService {
     private final MemberWatchlistRepository memberWatchlistRepository;
 
     private final StockNameValidator stockNameValidator;
-    private final StockKeywordResolver stockKeywordResolver;
+    private final TickerParser tickerParser;
 
     private final FcmService fcmService;
     private final ObjectMapper objectMapper;
@@ -86,7 +89,8 @@ public class AlertService {
                         throw new IllegalArgumentException("유효하지 않은 stockName 입니다.");
                     }
 
-                    String stockKeyword = stockType.equals("korea") ? stockName : stockKeywordResolver.resolve(stockName);
+                    String stockKeyword = stockType.equals("korea") ? stockName : tickerParser.parseTicker(stockName);
+                    ;
                     Watchlist newWatchlist = Watchlist.of(stockName, stockKeyword);
                     return watchlistRepository.save(newWatchlist);
                 });

--- a/src/main/java/datastreams_knu/bigpicture/common/util/StockKeywordResolver.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/util/StockKeywordResolver.java
@@ -26,4 +26,6 @@ public class StockKeywordResolver {
         }
         return response.getStockName();
     }
+
+
 }

--- a/src/main/java/datastreams_knu/bigpicture/common/util/TickerParser.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/util/TickerParser.java
@@ -1,0 +1,51 @@
+package datastreams_knu.bigpicture.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import datastreams_knu.bigpicture.common.config.AiModelConfig;
+import datastreams_knu.bigpicture.common.exception.ObjectMapperException;
+import datastreams_knu.bigpicture.schedule.service.dto.RecommendedKeywordDto;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static datastreams_knu.bigpicture.common.util.TickerParserPrompt.TICKER_PARSER_PROMPT;
+
+@RequiredArgsConstructor
+@Component
+public class TickerParser {
+
+    private final AiModelConfig aiModelConfig;
+    private final ObjectMapper objectMapper;
+
+    private ChatLanguageModel model;
+
+    @PostConstruct
+    public void init() {
+        this.model = aiModelConfig.openAiChatModel();
+    }
+
+    public String parseTicker(String ticker) {
+        try {
+            UserMessage prompt = createPrompt(ticker);
+
+            String response = model.chat(prompt).aiMessage().text();
+
+            RecommendedKeywordDto recommendedKeywordDto = objectMapper.readValue(response, RecommendedKeywordDto.class);
+            return recommendedKeywordDto.getKeyword();
+        } catch (JsonProcessingException e) {
+            throw new ObjectMapperException("Json 파싱 중 예외가 발생하였습니다.", e);
+        }
+    }
+
+    private UserMessage createPrompt(String ticker) {
+        String basePrompt = TICKER_PARSER_PROMPT;
+
+        String prompt = basePrompt.formatted(ticker);
+
+        UserMessage userMessage = new UserMessage(prompt);
+        return userMessage;
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/schedule/service/SchedulerService.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/service/SchedulerService.java
@@ -1,7 +1,7 @@
 package datastreams_knu.bigpicture.schedule.service;
 
-import datastreams_knu.bigpicture.common.util.StockKeywordResolver;
 import datastreams_knu.bigpicture.common.util.StockNameValidator;
+import datastreams_knu.bigpicture.common.util.TickerParser;
 import datastreams_knu.bigpicture.common.util.WebClientUtil;
 import datastreams_knu.bigpicture.schedule.controller.dto.RegisterCrawlingDataResponse;
 import datastreams_knu.bigpicture.schedule.entity.CrawlingInfo;
@@ -35,8 +35,8 @@ public class SchedulerService {
     private final CrawlingInfoRepository crawlingInfoRepository;
     private final CrawlingSeedRepository crawlingSeedRepository;
 
-    private final StockKeywordResolver stockKeywordResolver;
     private final StockNameValidator stockNameValidator;
+    private final TickerParser tickerParser;
 
     public RegisterCrawlingDataResponse registerCrawlingData(RegisterCrawlingDataServiceRequest request) {
         // 이미 존재하는 크롤링 정보
@@ -47,7 +47,7 @@ public class SchedulerService {
 
         String crawlingKeyword = request.getStockName();
         if (request.getStockType().equals("us")) {
-            crawlingKeyword = stockKeywordResolver.resolve(request.getStockName());
+            crawlingKeyword = tickerParser.parseTicker(request.getStockName());
         }
 
         // 실제 있는 stock인지 확인 필요


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- stockName(티커 등)이 들어오면 뉴스용 키워드로 파싱 되어야 하는 부분에 티커로 변환하는 코드가 적용되어 있어 이를 수정하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-